### PR TITLE
explicitly request privileges only where needed

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: 'restart chrony'
+  become: yes
   service:
     name: "{{ chrony_service_name }}"
     state: 'restarted'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,6 @@
 ---
 - name: 'Configure Chrony'
+  become: yes
   template:
     src: 'chrony.conf.j2'
     dest: "{{ chrony_conf_file }}"

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -1,5 +1,6 @@
 ---
 - name: '{{ ansible_os_family }} - Install Chrony'
+  become: yes
   apt:
     name: 'chrony'
     state: 'present'

--- a/tasks/install_redhat.yml
+++ b/tasks/install_redhat.yml
@@ -1,5 +1,6 @@
 ---
 - name: '{{ ansible_os_family }} - Install Chrony'
+  become: yes
   yum:
     name: 'chrony'
     state: 'present'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,5 +1,6 @@
 ---
 - name: 'Manage the chrony service'
+  become: yes
   service:
     name: '{{ chrony_service_name }}'
     enabled: '{{ chrony_service_enabled }}'


### PR DESCRIPTION
Hi @pmyjavec this PR is so I can avoid including the entire role with `become: yes`. Our team thinks it is bad practice to grant root to an entire 3rd party role.