### PR TITLE
Import tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,6 @@
     - 'chrony'
     - 'chrony-vars'
 
-- include: "install_{{ ansible_os_family | lower}}.yml"
-- include: "configure.yml"
-- include: "service.yml"
+- import_tasks: "install_{{ ansible_os_family | lower}}.yml"
+- import_tasks: "configure.yml"
+- import_tasks: "service.yml"


### PR DESCRIPTION
Hi @pmyjavec this changes `include`s to `import_task`s to avoid deprecation warnings.