### PR TITLE
Simplify using package module

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
-- name: '{{ ansible_os_family }} - Install Chrony'
-  yum:
+- name: 'Install Chrony'
+  package:
     name: 'chrony'
     state: 'present'
   tags:

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -1,8 +1,0 @@
----
-- name: '{{ ansible_os_family }} - Install Chrony'
-  apt:
-    name: 'chrony'
-    state: 'present'
-  tags:
-    - 'chrony-install'
-    - 'chrony'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,6 @@
     - 'chrony'
     - 'chrony-vars'
 
-- include: "install_{{ ansible_os_family | lower}}.yml"
+- include: "install.yml"
 - include: "configure.yml"
 - include: "service.yml"


### PR DESCRIPTION
Hi @pmyjavec I thought since the package name is the same in Debian/Redhat, maybe it makes sense to simplify the installation using the `package` module