### PR TITLE
Updated ffi and rubyzip gems 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     builder (3.2.3)
     erubis (2.7.0)
-    ffi (1.9.18)
+    ffi (1.9.25)
     gssapi (1.2.0)
       ffi (>= 1.0.1)
     gyoku (1.3.1)
@@ -35,7 +35,7 @@ GEM
       net-ssh (>= 2.6.5)
     nori (2.6.0)
     rubyntlm (0.6.2)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     test-kitchen (1.19.2)
       mixlib-install (~> 3.6)
@@ -77,4 +77,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.1


### PR DESCRIPTION
pushed to remove security vulnerability nags due to https://github.com/influxdata/ansible-chrony/issues/7 did not verify/test with kitchen 😐 

