### PR TITLE
Configuration options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+chrony_port: 123
+chrony_acquisitionport: 1123
 chrony_service_enabled: 'yes'
 chrony_service_state: 'started'
 chrony_service_name: 'chrony'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 chrony_port: 123
 chrony_acquisitionport: 1123
+chrony_allow:
 chrony_service_enabled: 'yes'
 chrony_service_state: 'started'
 chrony_service_name: 'chrony'

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -1,6 +1,14 @@
 # {{ ansible_managed }}
 # See https://chrony.tuxfamily.org/documentation.html for details on this file
 
+{% if chrony_port %}
+port {{ chrony_port }}
+{% endif %}
+
+{% if chrony_acquisitionport %}
+acquisitionport {{ chrony_acquisitionport }}
+{% endif %}
+
 {% if chrony_pool %}
 pool {{ chrony_pool }}
 {% endif %}
@@ -32,7 +40,6 @@ initstepslew {{ chrony_initstepslew_threshold }} {{ chrony_initstepslew_servers 
 
 # This directive designates subnets (or nodes) from which NTP clients are allowed
 # to access to 'chronyd'.
-
 #allow foo.example.net
 #allow 10/8
 #allow 0/0 (allow access by any IPv4 node)

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -38,12 +38,13 @@ initstepslew {{ chrony_initstepslew_threshold }} {{ chrony_initstepslew_servers 
 
 #local stratum 10
 
+{% if chrony_allow %}
 # This directive designates subnets (or nodes) from which NTP clients are allowed
 # to access to 'chronyd'.
-#allow foo.example.net
-#allow 10/8
-#allow 0/0 (allow access by any IPv4 node)
-#allow ::/0 (allow access by any IPv6 node)
+{% for block in chrony_allow %}
+allow {{ block }}
+{% endfor %}
+{% endif %}
 
 # This directive forces `chronyd' to send a message to syslog if it
 # makes a system clock adjustment larger than a threshold value in seconds.


### PR DESCRIPTION
Due to some firewall restrictions I have need to change some ports. 

I'm using chrony in a server configuration and the allow option enables this.  The variable is left blank to keep the default behavior of chrony only being a client without the allow option.