### PR TITLE
VTWO-14604: Adapt chrony configuration with its version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,8 @@ chrony_conf_file: '/etc/chrony/chrony.conf'
 chrony_keyfile: '/etc/chrony/chrony.keys'
 chrony_pool: # 2.debian.pool.ntp.org offline iburst
 # AWS Time Sync service default
-chrony_server: '169.254.169.123 prefer iburst'
+chrony_server: '169.254.169.123'
+chrony_server_subcommand: 'prefer iburst'
 chrony_driftfile: '/var/lib/chrony/chrony.drift'
 chrony_log: 'tracking measurements statistics'
 chrony_logdir: '/var/log/chrony'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,12 @@
 ---
+- name: 'Get version'
+  shell: "aptitude versions chrony | grep '^i' | awk '{print $2}'"
+  check_mode: no
+  register: register_version
+
+- debug:
+    var: register_version.stdout
+
 - name: 'Configure Chrony'
   become: yes
   template:

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -6,11 +6,15 @@ pool {{ chrony_pool }}
 {% endif %}
 
 {% if chrony_server %}
-server {{ chrony_server }}
+server {{ chrony_server }} {% if chrony_server_subcommand and register_version.stdout is version('1.25', '>=') %}
+{{ chrony_server_subcommand }}
+{% endif %}
 {% endif %}
 
 keyfile {{ chrony_keyfile }}
+{% if register_version.stdout is version('2.2', '<')  %}
 commandkey 1
+{% endif %}
 
 driftfile {{ chrony_driftfile }}
 log {{ chrony_log }}
@@ -49,13 +53,16 @@ logchange 0.5
 
 # mailonchange root@localhost 0.5
 
+{% if register_version.stdout is version('1.25', '>=')  %}
 # This directive tells 'chronyd' to parse the 'adjtime' file to find out if the
 # real-time clock keeps local time or UTC. It overrides the 'rtconutc' directive.
 
 hwclockfile /etc/adjtime
+{% endif %}
 
+{% if register_version.stdout is version('2.1.1', '>=')  %}
 # This directive enables kernel synchronisation (every 11 minutes) of the
 # real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
 
 rtcsync
-
+{% endif %}


### PR DESCRIPTION
Chrony 1.24 does not recognize the directives:
* hwclockfile
* rtcsync
* the subcommands prefer and iburst of the direcitve server

Chrony version > 2.2 does not recognize the directive:
* commandkey

I managed only the directives which cause some error logs.